### PR TITLE
Critical error fixed

### DIFF
--- a/include/select.h
+++ b/include/select.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include "editor.h"
 
-Point selection_start;
-Point selection_end;
+extern Point selection_start;
+extern Point selection_end;
 
 void start_selection(int y, int x);
 void update_selection(int y, int x);

--- a/src/select.c
+++ b/src/select.c
@@ -4,6 +4,8 @@
 #include "editor.h"
 
 static bool selecting = false;
+Point selection_start;
+Point selection_end;
 
 void start_selection(int y, int x) {
     if (!selecting) {


### PR DESCRIPTION
Before the fix, if you tried to compile it, it wouldn't work with this error message:
```
/usr/bin/ld: CMakeFiles/tomo.dir/src/draw.c.o:/home/ict/.sources/Tomo/include/select.h:7: multiple definition of `selection_start'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:7: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/draw.c.o:/home/ict/.sources/Tomo/include/select.h:8: multiple definition of `selection_end'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:8: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/edit.c.o:/home/ict/.sources/Tomo/include/select.h:7: multiple definition of `selection_start'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:7: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/edit.c.o:/home/ict/.sources/Tomo/include/select.h:8: multiple definition of `selection_end'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:8: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/input.c.o:/home/ict/.sources/Tomo/include/select.h:7: multiple definition of `selection_start'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:7: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/input.c.o:/home/ict/.sources/Tomo/include/select.h:8: multiple definition of `selection_end'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:8: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/select.c.o:/home/ict/.sources/Tomo/include/select.h:7: multiple definition of `selection_start'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:7: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/select.c.o:/home/ict/.sources/Tomo/include/select.h:8: multiple definition of `selection_end'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:8: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/undo.c.o:/home/ict/.sources/Tomo/include/select.h:7: multiple definition of `selection_start'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:7: first defined here
/usr/bin/ld: CMakeFiles/tomo.dir/src/undo.c.o:/home/ict/.sources/Tomo/include/select.h:8: multiple definition of `selection_end'; CMakeFiles/tomo.dir/src/cursor.c.o:/home/ict/.sources/Tomo/include/select.h:8: first defined here
```

After the fix, compilation goes as expected