### PR TITLE
feat: ctrl+l to select line

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -108,6 +108,16 @@ void handle_key(int key) {
         save_undo_snapshot = true;
     }
 
+    // CTRL + L (SELECT A SINGLE LINE)
+    if (key == 12) {
+        start_selection(cursor.y + cursor.y_offset, 0);
+        int line_len = strlen(editor.lines[cursor.y + cursor.y_offset]);
+        cursor.x = editor.margin + line_len - cursor.x_offset;
+        clamp_cursor();
+        update_selection(cursor.y + cursor.y_offset,
+                        cursor.x - editor.margin + cursor.x_offset);
+        save_undo_snapshot = true;
+    }
     if (key == 535 &&
         cursor.y + cursor.y_offset <
             editor.total_lines +


### PR DESCRIPTION
Key combination: `CTRL+L`
ASCII Control code: 12
<img width="150" height="26" alt="image" src="https://github.com/user-attachments/assets/7f12efcb-cf82-4cbe-a230-a793097e03f6" />

### Feature added
- [x] User can select a line like in Vs Code with `CTRL+L` as key combination


