### PR TITLE
Feat: file/folder search available in ctrl+e and ./ and ../ are at top at tree by default

### DIFF
--- a/src/file_tree.c
+++ b/src/file_tree.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/stat.h>
+#include <string.h>
 
 #include "themes.h"
 #include "fileio.h"
@@ -18,32 +19,47 @@ void draw_tree(char **files, int el_num, char *dir_path) {
 
     keypad(tree_win, TRUE);
     wbkgd(tree_win, COLOR_PAIR(PAIR_BACKGROUND));
-    curs_set(0);
+    curs_set(1);
+    char search_buffer[256] = {0};
+    int search_pos = 0;
 
+    char *filtered[1024];
+    int filtered_count = 0;
     int pos = 0;
     int ch = 0;
     while (ch != '\n') {
         werase(tree_win);
+        filtered_count = 0;
         for (int i = 0; i < el_num; i++) {
+            if (search_buffer[0] == '\0' || strcasestr(files[i], search_buffer)) {
+                filtered[filtered_count++] = files[i];
+            }
+        }
+        if (pos >= filtered_count) pos = filtered_count - 1;
+        if (pos < 0) pos = 0;
+
+        for (int i = 0; i < filtered_count; i++) {
             if (i == pos) {
                 wattron(tree_win, COLOR_PAIR(PAIR_STATUS_BAR));
                 mvwhline(tree_win, i, 0, ' ', max_x);
-                mvwprintw(tree_win, i, 0, " %s", files[i]);
+                mvwprintw(tree_win, i, 0, " %s", filtered[i]);
                 wattroff(tree_win, COLOR_PAIR(PAIR_STATUS_BAR));
             } else {
-                mvwprintw(tree_win, i, 0, " %s", files[i]);
+                mvwprintw(tree_win, i, 0, " %s", filtered[i]);
             }
         }
+
+        mvwprintw(tree_win, max_y - 1, 0, "> %s", search_buffer);
         wrefresh(tree_win);
         ch = wgetch(tree_win);
 
         switch (ch) {
             case KEY_UP:
                 if (pos > 0) pos--;
-                else pos = el_num - 1;
+                else pos = filtered_count - 1;
                 break;
             case KEY_DOWN:
-                if (pos < el_num - 1) pos++;
+                if (pos < filtered_count - 1) pos++;
                 else pos = 0;
                 break;
 
@@ -52,13 +68,24 @@ void draw_tree(char **files, int el_num, char *dir_path) {
                 endwin();
                 reset();
                 exit(0);
+            case KEY_BACKSPACE:
+                if (search_pos > 0) {
+                    search_buffer[--search_pos] = '\0';
+                }
+                break;
+            default:
+                if (ch > 31 && ch < 127 && search_pos < (int)sizeof(search_buffer) - 1) {
+                    search_buffer[search_pos++] = ch;
+                    search_buffer[search_pos] = '\0';
+                }
+                break;
+
         }
     }
-
     delwin(tree_win);
 
     char path[PATH_MAX];
-    snprintf(path, PATH_MAX, "%s/%s", dir_path, files[pos]);
+    snprintf(path, PATH_MAX, "%s/%s", dir_path, filtered[pos]);
     char *real_path = realpath(path, NULL);
 
     // Check if path is a directory

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -166,20 +166,14 @@ void open_dir(char *path) {
         // put './' and '../' both at top
         // TODO: we can sort files and directories alphabetically
         for (int i = 0; i < dir_count; i++) {
-            if (strcmp(directories[i], "./") == 0) {
+            if (strcmp(directories[i], "./") == 0 || strcmp(directories[i], "../") == 0) {
                 elements[element_count++] = directories[i];
-                break;
+                directories[i] = NULL; // MARK AS USED
             }
         }
-        for (int i = 0; i < dir_count; i++) {
-            if (strcmp(directories[i], "../") == 0) {
-                elements[element_count++] = directories[i];
-                break;
-            }
-        }   
 
         for (int i = 0; i < dir_count; i++) {
-            if (strcmp(directories[i], "./") != 0 && strcmp(directories[i], "../") != 0) {
+            if (directories[i] != NULL) {
                 elements[element_count++] = directories[i];
             }
         }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -162,8 +162,27 @@ void open_dir(char *path) {
     
     // First put directories into elements array
     int element_count = 0;
-    for (int i = 0; i < dir_count; i++) {
-        elements[element_count++] = directories[i];
+    if (dir_count > 0) {
+        // put './' and '../' both at top
+        // TODO: we can sort files and directories alphabetically
+        for (int i = 0; i < dir_count; i++) {
+            if (strcmp(directories[i], "./") == 0) {
+                elements[element_count++] = directories[i];
+                break;
+            }
+        }
+        for (int i = 0; i < dir_count; i++) {
+            if (strcmp(directories[i], "../") == 0) {
+                elements[element_count++] = directories[i];
+                break;
+            }
+        }   
+
+        for (int i = 0; i < dir_count; i++) {
+            if (strcmp(directories[i], "./") != 0 && strcmp(directories[i], "../") != 0) {
+                elements[element_count++] = directories[i];
+            }
+        }
     }
 
     // Then put files


### PR DESCRIPTION
## Pull Request details

- [x] added file/folder search on filetree
- [x] ./ and ../ are at top by default (can be refactored further)
 
### File/Folder search
code was referenced from file `command__palette.c`