### PR TITLE
Trying to solve keycodes mess

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ select = "#333333"
 - <kbd>Ctrl + P</kbd> - Open command palette
 - <kbd>Arrow keys</kbd> - Move cursor
 - <kbd>Arrow keys + Shift</kbd> - Start text selection
+- <kbd>Arrow keys + Ctrl</kbd> - Jump to the start/end of the line/file
 
 ## Installation
 

--- a/include/command_palette.h
+++ b/include/command_palette.h
@@ -7,6 +7,7 @@ enum Action {
     SAVE_FILE,
     OPEN_FILE,
     UNDO,
+    REDO,
     EXIT,
 };
 

--- a/include/input.h
+++ b/include/input.h
@@ -1,6 +1,7 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+void define_esc_arrows(void);
 void handle_key(int key);
 
 #endif

--- a/src/command_palette.c
+++ b/src/command_palette.c
@@ -102,7 +102,7 @@ static int draw_palette(char **items, int n_items, char *buf, size_t buf_size) {
 }
 
 int draw_command_palette(void) {
-    char *options[] = {"Change theme", "Go to line", "Save file", "Open file", "Undo", "Exit"};
+    char *options[] = {"Change theme", "Go to line", "Save file", "Open file", "Undo", "Redo", "Exit"};
     char buf[64] = {0};
     return draw_palette(options, sizeof(options) / sizeof(options[0]), buf, sizeof(buf));
 }

--- a/src/input.c
+++ b/src/input.c
@@ -1,4 +1,4 @@
-#include "input.h"
+#include "input.h"inpu
 
 #include <curses.h>
 #include <stdlib.h>
@@ -204,6 +204,10 @@ void handle_key(int key) {
 
         case UNDO:
             undo();
+            break;
+
+        case REDO:
+            redo();
             break;
 
         case EXIT:

--- a/src/main.c
+++ b/src/main.c
@@ -22,9 +22,9 @@ int main(int argc, char *argv[]) {
     }
 
     struct stat dir_path;
-    stat(argv[1], &dir_path);
+    int stat_res = stat(argv[1], &dir_path);
 
-    if (S_ISDIR(dir_path.st_mode)) {
+    if (!stat_res && S_ISDIR(dir_path.st_mode)) {
         init_curses();
         init_colors();
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "syntax.h"
 #include "themes.h"
 #include "undo.h"
+#include "input.h"
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
@@ -47,6 +48,7 @@ int main(int argc, char *argv[]) {
     init_variables();
     syntax_init();
     init_undo_redo_stacks();
+    define_esc_arrows();
 
     curs_set(1);
 


### PR DESCRIPTION
This pull request tries to increase readability of the input.c code and fixes some issues with arrow keys.

First of all, I suggest using ctrl macro to get keycode instead of writing keycode in if statements.
Instead of this:
`if (key == 17) { // CTRL + Q (Quit the editor) ... }`
Now it will look like this:
`if (key == CTRL('q')) { // (Quit the editor) ... }`

Keycodes, that are not defined by ncurses should be defined at the start of input.c file:
Instead of:
`if (key == 27) { // Esc ... }`
It will look like this:
`if (key == KEY_ESCAPE) { ... }`

Arrows with modifiers now are definded as escape sequences for better portability between terminals.
Also I changed ctrl + arrows to continue selection when it is started and added redo to command palette.

Third commit checks if the stat function succeed before opening directory to prevent getting an "no such directory" error when user wants to create a new file.